### PR TITLE
fix: redefine new line delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ import { WithContext as ReactTags } from 'react-tag-input';
 
 const KeyCodes = {
   comma: 188,
-  enter: 13,
+  enter: [10, 13],
 };
 
-const delimiters = [KeyCodes.comma, KeyCodes.enter];
+const delimiters = [...KeyCodes.enter, KeyCodes.comma];
 
 class App extends React.Component {
     constructor(props) {

--- a/__tests__/__snapshots__/reactTags.test.js.snap
+++ b/__tests__/__snapshots__/reactTags.test.js.snap
@@ -9,6 +9,7 @@ Object {
   "autocomplete": false,
   "autofocus": true,
   "delimiters": Array [
+    10,
     13,
     9,
   ],

--- a/__tests__/reactTags.test.js
+++ b/__tests__/reactTags.test.js
@@ -206,6 +206,37 @@ describe('Test ReactTags', () => {
       expect(tags).to.deep.have.same.members(expected);
     });
 
+    test('should split the clipboard when delimited with new lines', () => {
+      const Keys = {
+        ENTER: [10, 13],
+      };
+
+      const tags = [];
+      const $el = mount(
+        mockItem({
+          delimiters: [...Keys.ENTER],
+          handleAddition(tag) {
+            tags.push(tag);
+          },
+          tags,
+        })
+      );
+
+      const $input = $el.find('.ReactTags__tagInputField');
+
+      $input.simulate('paste', {
+        clipboardData: {
+          getData: () => 'Banana\nApple\rApricot\r\n\r\nOrange',
+        },
+      });
+
+      const expected = ['Banana', 'Apple', 'Apricot', 'Orange'].map(
+        (value) => ({ id: value, text: value })
+      );
+
+      expect(tags).to.deep.have.same.members(expected);
+    });
+
     test('should not allow duplicate tags', () => {
       const Keys = {
         TAB: 9,

--- a/example/main.js
+++ b/example/main.js
@@ -219,10 +219,10 @@ const suggestions = COUNTRIES.map((country) => {
 
 const KeyCodes = {
   comma: 188,
-  enter: 13,
+  enter: [10, 13],
 };
 
-const delimiters = [KeyCodes.comma, KeyCodes.enter];
+const delimiters = [...KeyCodes.enter, KeyCodes.comma];
 
 const Tags = ReactTags.WithContext;
 

--- a/src/components/ReactTags.js
+++ b/src/components/ReactTags.js
@@ -73,7 +73,7 @@ class ReactTags extends Component {
     placeholder: DEFAULT_PLACEHOLDER,
     labelField: DEFAULT_LABEL_FIELD,
     suggestions: [],
-    delimiters: [KEYS.ENTER, KEYS.TAB],
+    delimiters: [...KEYS.ENTER, KEYS.TAB],
     autofocus: true,
     inline: true, // TODO: Remove in v7.x.x
     inputFieldPosition: INPUT_FIELD_POSITIONS.INLINE,

--- a/src/components/RemoveComponent.js
+++ b/src/components/RemoveComponent.js
@@ -7,7 +7,7 @@ const RemoveComponent = (props) => {
   const { readOnly, removeComponent, onRemove, className, tag, index } = props;
 
   const onKeydown = (event) => {
-    if (event.keyCode === KEYS.ENTER || event.keyCode === KEYS.SPACE) {
+    if (KEYS.ENTER.indexOf(event.keyCode) !== -1 || event.keyCode === KEYS.SPACE) {
       event.preventDefault();
       event.stopPropagation();
       return;

--- a/src/components/RemoveComponent.js
+++ b/src/components/RemoveComponent.js
@@ -7,7 +7,7 @@ const RemoveComponent = (props) => {
   const { readOnly, removeComponent, onRemove, className, tag, index } = props;
 
   const onKeydown = (event) => {
-    if (KEYS.ENTER.indexOf(event.keyCode) !== -1 || event.keyCode === KEYS.SPACE) {
+    if (KEYS.ENTER.includes(event.keyCode) || event.keyCode === KEYS.SPACE) {
       event.preventDefault();
       event.stopPropagation();
       return;

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,5 +1,5 @@
 export const KEYS = {
-  ENTER: 13,
+  ENTER: [10, 13],
   TAB: 9,
   BACKSPACE: 8,
   UP_ARROW: 38,


### PR DESCRIPTION
fixes #721 

Fixes problem with pasting multiline text. 
Based on the https://github.com/react-tags/react-tags/blob/master/src/components/constants.js#L2 , enter delimiter is marked as unicode `13` (Carriage return), which is partially true. Enter should be also marked with unicode `10` (Line feed). Please see https://stackoverflow.com/a/1761064
That means on windows/edge it works in partial - it splits a text by `\r`:  `word1\r\nword2` -> `['word1', '\nword2']` but in other systems it does not split text at all.

Tested on Chrome, Safari, Edge, Firefox
