### PR TITLE
fix: Add type to remove button

### DIFF
--- a/__tests__/RemoveComponent.test.js
+++ b/__tests__/RemoveComponent.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { stub } from 'sinon';
+
+import RemoveComponent from '../src/components/RemoveComponent';
+
+describe('Test <RemoveComponent/>', () => {
+  let minProps, onRemoveStub;
+  beforeAll(() => {
+    onRemoveStub = stub();
+    minProps = {
+      onRemove: onRemoveStub,
+      index: 0,
+      tag: {
+        id: 'Tags',
+        key: 'Tags',
+      },
+    };
+  });
+  afterAll(() => {
+    onRemoveStub.restore();
+  });
+
+  it('should render with base structure', () => {
+    const wrapper = shallow(<RemoveComponent {...minProps} />);
+    jestExpect(wrapper).toMatchSnapshot();
+  });
+});

--- a/__tests__/__snapshots__/RemoveComponent.test.js.snap
+++ b/__tests__/__snapshots__/RemoveComponent.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test <RemoveComponent/> should render with base structure 1`] = `
+<button
+  aria-label="Tag at index 0 with value Tags focussed. Press backspace to remove"
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  type="button"
+>
+  ×
+</button>
+`;

--- a/jest.config.js
+++ b/jest.config.js
@@ -132,7 +132,7 @@ module.exports = {
   setupTestFrameworkScriptFile: '<rootDir>/__tests__/setupTest.js',
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-  // snapshotSerializers: [],
+  snapshotSerializers: ['enzyme-to-json/serializer'],
 
   // The test environment that will be used for testing
   // testEnvironment: "jest-environment-jsdom",
@@ -187,5 +187,5 @@ module.exports = {
 
   // Whether to use watchman for file crawling
   // watchman: true,
-  "testURL": "http://localhost/"
+  testURL: 'http://localhost/',
 };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "css-loader": "^5.2.6",
     "cz-conventional-changelog": "^3.3.0",
     "enzyme": "^3.11.0",
+    "enzyme-to-json": "^3.6.2",
     "eslint": "^7.3.1",
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/src/components/RemoveComponent.js
+++ b/src/components/RemoveComponent.js
@@ -41,6 +41,7 @@ const RemoveComponent = (props) => {
       onClick={onRemove}
       onKeyDown={onKeydown}
       className={className}
+      type="button"
       aria-label={ariaLabel}>
       {crossStr}
     </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,6 +593,13 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
   integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
+"@types/cheerio@^0.22.22":
+  version "0.22.30"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.30.tgz#6c1ded70d20d890337f0f5144be2c5e9ce0936e6"
+  integrity sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -4003,6 +4010,15 @@ enzyme-shallow-equal@^1.0.0, enzyme-shallow-equal@^1.0.1:
   dependencies:
     has "^1.0.3"
     object-is "^1.1.2"
+
+enzyme-to-json@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.6.2.tgz#94f85c413bcae8ab67be53b0a94b69a560e27823"
+  integrity sha512-Ynm6Z6R6iwQ0g2g1YToz6DWhxVnt8Dy1ijR2zynRKxTyBGA8rCDXU3rs2Qc4OKvUvc2Qoe1bcFK6bnPs20TrTg==
+  dependencies:
+    "@types/cheerio" "^0.22.22"
+    lodash "^4.17.21"
+    react-is "^16.12.0"
 
 enzyme@^3.11.0:
   version "3.11.0"
@@ -9011,15 +9027,15 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-is@^16.7.0, react-is@^16.8.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"


### PR DESCRIPTION
I wish to use ReactTags inside a form
To prevent tag's removing when I press on Enter (to submit the form), I do need to set a type to all my buttons.
ReactTags did not set any type to this RemoveComponent's button. So I added it.