### PR TITLE
fix: use yarn install instead of npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "14"
 before_install:
 - npm install -g yarn
-install: npm install
+install: yarn
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter


### PR DESCRIPTION
fix the breaking build in [6.7.2](https://app.travis-ci.com/github/react-tags/react-tags/builds/232481517)