### PR TITLE
fix: remove undefined onkeydown prop passed to RemoveComponent

### DIFF
--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -59,7 +59,6 @@ const Tag = (props) => {
         onRemove={props.onDelete}
         readOnly={readOnly}
         index={index}
-        onKeyDown={onkeydown}
       />
     </span>
   );


### PR DESCRIPTION
this fixes #795 

removed `onKeyDown` prop passed `RemoveComponent` component as it doesn't have this prop registered and i believe this was added by mistake (with onKeyDown being undefined)
also the `onKeyDown` is already handled inside the `RemoveComponent` component