### PR TITLE
fix: add missing required class selector prefix for scrolling active suggestion

### DIFF
--- a/src/components/Suggestions.js
+++ b/src/components/Suggestions.js
@@ -57,7 +57,7 @@ class Suggestions extends Component {
       prevProps.selectedIndex !== selectedIndex
     ) {
       const activeSuggestion = this.suggestionsContainer.querySelector(
-        classNames.activeSuggestion
+        `.${classNames.activeSuggestion}`
       );
 
       if (activeSuggestion) {


### PR DESCRIPTION
The suggestion `scrollTop` feature isn't working because the `querySelector` API requires a selector prefix for classes (`.`).

This was originally implemented in https://github.com/react-tags/react-tags/pull/93.