### PR TITLE
chore: change globs in npm format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest --notify --coverage",
     "test:watch": "jest --watch --notify --coverage",
     "start": "webpack serve --config webpack-dev-server.config.js --progress --inline --color",
-    "format": "prettier  --write src/*.js __tests__/*.js",
+    "format": "prettier  --write src/**/*.js __tests__/**/*.js",
     "build": "webpack --config webpack-production.config.js --progress --color && babel src --out-dir dist-modules --copy-files",
     "precommit": "./set_up_hooks.sh",
     "semantic-release": "semantic-release",


### PR DESCRIPTION
The globs used in the `format` script are incorrect for nested files and is logging a "No files matching the pattern were found" error