### PR TITLE
fix: delete tag when backspace is pressed only when input field position is inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,11 +309,13 @@ Optional boolean param to control whether the text-input should be autofocused o
 ```
 
 ### allowDeleteFromEmptyInput
-Optional boolean param to control whether tags should be deleted when the 'Delete' key is pressed in an empty Input Box.
+Optional boolean param to control whether tags should be deleted when the 'Delete' key is pressed in an empty Input Box. By default this prop is false. However when input field position is inline, you will be able to delete the tags by pressing "Backspace" irrespective of the value of this prop.
+
+This prop will likely be removed in future versions.
 
 ```js
 <ReactTags
-    allowDeleteFromEmptyInput={false}
+    allowDeleteFromEmptyInput={true}
     ...>
 ```
 ### handleInputChange

--- a/README.md
+++ b/README.md
@@ -309,7 +309,9 @@ Optional boolean param to control whether the text-input should be autofocused o
 ```
 
 ### allowDeleteFromEmptyInput
-Optional boolean param to control whether tags should be deleted when the 'Delete' key is pressed in an empty Input Box. By default this prop is false. However when input field position is inline, you will be able to delete the tags by pressing "Backspace" irrespective of the value of this prop.
+Optional boolean param to control whether tags should be deleted when the `Backspace` key is pressed in an empty Input Box. By default this prop is `false`. 
+
+However when input field position is `inline`, you will be able to delete the tags by pressing `Backspace` irrespective of the value of this prop.
 
 This prop will likely be removed in future versions.
 

--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -968,6 +968,34 @@ describe('Test ReactTags', () => {
       ).to.equal('ReactTags__tagInput');
     });
 
+    it('should delete the last tag when query is empty, input position is inline and backspace is pressed', () => {
+      const handleDeleteStub = sandbox.stub();
+      const wrapper = mount(
+        mockItem({
+          tags: [
+            {
+              id: 'Apple',
+              text: 'Apple',
+            },
+            {
+              id: 'Orange',
+              text: 'Orange',
+            },
+            {
+              id: 'Banana',
+              text: 'Banana',
+            },
+          ],
+          handleDelete: handleDeleteStub,
+          inputFieldPosition: INPUT_FIELD_POSITIONS.INLINE,
+        })
+      );
+      expect(wrapper.find(PureReactTags).props().tags).to.have.length(3);
+      const input = wrapper.find('.ReactTags__tagInputField');
+      input.simulate('keyDown', { key: 'Backspace' });
+      expect(handleDeleteStub.calledWith(2)).to.be.true;
+    });
+
     it('should display input field above tags when "inputFieldPosition" is top', () => {
       const $el = mount(
         mockItem({

--- a/__tests__/__snapshots__/ReactTags.test.tsx.snap
+++ b/__tests__/__snapshots__/ReactTags.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Test ReactTags should render with expected props 1`] = `
 {
   "allowAdditionFromPaste": true,
-  "allowDeleteFromEmptyInput": true,
+  "allowDeleteFromEmptyInput": false,
   "allowDragDrop": true,
   "allowUnique": true,
   "autocomplete": false,

--- a/example/main.js
+++ b/example/main.js
@@ -284,7 +284,7 @@ const App = () => {
           handleDrag={handleDrag}
           handleTagClick={handleTagClick}
           onTagUpdate={onTagUpdate}
-          inputFieldPosition="top"
+          inputFieldPosition="bottom"
           autocomplete
           editable
           clearAll

--- a/example/main.js
+++ b/example/main.js
@@ -284,7 +284,7 @@ const App = () => {
           handleDrag={handleDrag}
           handleTagClick={handleTagClick}
           onTagUpdate={onTagUpdate}
-          inputFieldPosition="bottom"
+          inputFieldPosition="top"
           autocomplete
           editable
           clearAll

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -482,12 +482,13 @@ const ReactTags = (props: ReactTagsProps) => {
         addTag(selectedQuery);
       }
     }
-
-    // when backspace key is pressed and query is blank, delete tag
+    // If the backspace key is pressed and the query is empty, delete the last tag if
+    // allowDeleteFromEmptyInput is true or if the input field is inline
     if (
-      event.keyCode === KEYS.BACKSPACE &&
+      event.key === 'Backspace' &&
       query === '' &&
-      allowDeleteFromEmptyInput
+      (allowDeleteFromEmptyInput ||
+        inputFieldPosition === INPUT_FIELD_POSITIONS.INLINE)
     ) {
       handleDelete(tags.length - 1, event);
     }
@@ -774,7 +775,7 @@ ReactTags.defaultProps = {
   inputFieldPosition: INPUT_FIELD_POSITIONS.INLINE,
   handleDelete: noop,
   handleAddition: noop,
-  allowDeleteFromEmptyInput: true,
+  allowDeleteFromEmptyInput: false,
   allowAdditionFromPaste: true,
   autocomplete: false,
   readOnly: false,


### PR DESCRIPTION
Deleting tags via backspace is needed and expected behaviour only when input position is inline. For `top/bottom` positions, the behaviour is confusing and looks buggy as well. Hence I am only keeping this behavior when the input field is `inline`.

- [x] delete tag when backspace is pressed only when input field position is inline

- [x] BREAKING CHANGE - Set the default value of allowDeleteFromEmptyInput to false as the behavior is semantically wrong for top/bottom positions

For now I am keeping the prop but, I feel that we don't need this prop as I don't see the use cases where people would like to have this behavior for top/bottom input field positions. I will open an issue regarding this so we can discuss it there
