### PR TITLE
build: Change export order

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "default": "./dist/index.js",
       "development": "./dist/index.js",
       "production": "./dist/index.min.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Make default export last in package.json.

Certain build tools (microbundle) require the default export to be last in the exports object.  See e.g. https://stackoverflow.com/questions/76127288/module-not-found-error-default-condition-should-be-last-one.