### PR TITLE
build: set resolve.fullySpecified to false so mjs/js imports without specifying extensions for ESM in webpack dev server

### DIFF
--- a/webpack-dev-server.config.cjs
+++ b/webpack-dev-server.config.cjs
@@ -50,6 +50,12 @@ const config = {
         // https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
         sideEffects: true,
       },
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false
+        }
+      }
     ],
   },
   resolve: {


### PR DESCRIPTION
For building the library we have moved to `esbuild` but dev server still uses `webpack` so should switch to `esbuild` completely soon or `vite`

Since webpack doesn't support importing files for module type packages (ESM) hence the field `resolve.fullySpecified` needs to be set to false to make the imports work, more info [here](https://webpack.js.org/configuration/module/#resolvefullyspecified)

closes https://github.com/ad1992/fuzzify/issues/15