### PR TITLE
fix(exports): properly export tag type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -303,3 +303,4 @@ const WithContext = ({ ...props }: ReactTagsWrapperProps) => (
 export { WithContext };
 export { ReactTagsWrapper as WithOutContext };
 export { KEYS, SEPARATORS };
+export { Tag };


### PR DESCRIPTION
This PR adds the export of the `Tag` type to the index file to allow users to import it via `import { Tag } from "react-tag-input";`