### PR TITLE
fix: load bundle.css so preview build works

### DIFF
--- a/example/main.tsx
+++ b/example/main.tsx
@@ -5,7 +5,7 @@ import GitHubCorner from './GithubCorner';
 import type { Tag } from '../src/components/SingleTag';
 import { WithContext as ReactTags } from '../src';
 import COUNTRIES from './countries';
-import { SEPARATORS } from '../src/components/constants';
+import { SEPARATORS } from '../src';
 
 import './reactTags.scss';
 

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <link rel="stylesheet" href="./bundle.min.css">
 </head>
 
 <body>
@@ -11,7 +12,7 @@
     <hr/>
     <div id='app'></div>
   </div>
-  <!-- include dependancies -->
+  <!-- include dependencies -->
   
   <script defer type="text/javascript" src="./bundle.min.js"></script>
 </body>


### PR DESCRIPTION
CSS was not being loaded since https://github.com/react-tags/react-tags/pull/971/files

closes #991 