### PR TITLE
fix: missing Tag export

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -303,3 +303,4 @@ const WithContext = ({ ...props }: ReactTagsWrapperProps) => (
 export { WithContext };
 export { ReactTagsWrapper as WithOutContext };
 export { KEYS, SEPARATORS };
+export { Tag };


### PR DESCRIPTION
Exported the `Tag` type to make it available for use in other parts of the application.