### PR TITLE
fix: Korean input trigger keydown event twice

### DIFF
--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Children } from 'react';
 import { expect } from 'chai';
+
 import { spy, stub, createSandbox } from 'sinon';
 
 import { WithContext as ReactTags } from '../src/index';
@@ -7,6 +8,8 @@ import { WithContext as ReactTags } from '../src/index';
 import { KEYS, SEPARATORS } from '../src/components/constants';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { Tag } from '../src/components/SingleTag';
+
+
 
 /* eslint-disable no-console */
 
@@ -1379,3 +1382,25 @@ describe('Test ReactTags', () => {
     });
   });
 });
+
+describe('multi-byte character language tags', () => {
+
+  it('should correctly add multi-byte character language tags', () => {   
+   const tags = [];
+    render(
+      mockItem({
+         handleAddition(tag) {
+          tags.push(tag);
+        },
+        suggestions: [],
+      })
+    );
+    const input = screen.getByTestId('input') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '안녕하세요' } });
+    
+    fireEvent.keyDown(input, { keyCode: ENTER_ARROW_KEY_CODE });
+    expect(tags.length).eq(1)
+  })
+ 
+})

--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React from 'react';
 import { expect } from 'chai';
 
 import { spy, stub, createSandbox } from 'sinon';

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -259,6 +259,11 @@ const ReactTags = (props: ReactTagsProps) => {
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+     const nativeEvent = event.nativeEvent as KeyboardEvent;
+
+    if (nativeEvent.isComposing) {
+      return;
+    }
     // hide suggestions menu on escape
     if (event.key === 'Escape') {
       event.preventDefault();


### PR DESCRIPTION
>[!NOTE]
> The solution needs to be tested by a proper Korean language user. Being a non-Korean language user, I can change the keyboard type and type input and test, but I will not be able to say whether what I tested is proper according to the Korean language, 

## Issue

Korean and Japanese languages characters are formed using the compositions of keys. 

From GPT:

Composition-based Input:
Korean, like many East Asian languages, often uses an Input Method Editor (IME) for text entry. This involves a composition process where multiple keystrokes may be required to form a single character.

Challenges:

1. The value of the input field may not be final until the composition is complete.
2. Key events may fire multiple times for a single Korean character.
3. The keyCode or which properties may not accurately represent the Korean character being input.

The issue we were facing is that the keys were still composing when we were handling `onKeyDown ` event. By the time the composition is done, it is used to trigger one more time enter and last character. 

can read more [here](https://github.com/vuejs/vue/issues/10277)

## Fix

Add a composing check-in on the KeyDown event to handle the next stages. Though Key events might fire multiple times, this makes sure, that until all composing is done enter is not triggered .
 
 
 Why the handling is added on `onKeyDown` event not on `onChange`?
 - we are concentrating on `enter key` which is the terminating key. It's not considered as value in the input tag. 

This fixes https://github.com/react-tags/react-tags/issues/988


## SCREEN RECORDINGS

English lang
https://github.com/user-attachments/assets/fe4060cf-d51f-4fa5-9efd-7f99a20f575f

Korean lang
https://github.com/user-attachments/assets/80ba9760-6184-4faa-8a76-4189ebc8901b


