### PR TITLE
fix: type issue in classNames prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -141,17 +141,17 @@ export interface ReactTagsWrapperProps {
    * CSS class names for the component.
    */
   classNames?: {
-    tags: string,
-    tagInput: string,
-    tagInputField: string,
-    selected: string,
-    tag: string,
-    remove: string,
-    suggestions: string,
-    activeSuggestion: string,
-    editTagInput: string,
-    editTagInputField: string,
-    clearAll: string,
+    tags?: string,
+    tagInput?: string,
+    tagInputField?: string,
+    selected?: string,
+    tag?: string,
+    remove?: string,
+    suggestions?: string,
+    activeSuggestion?: string,
+    editTagInput?: string,
+    editTagInputField?: string,
+    clearAll?: string,
   };
   /**
    * Name attribute for the input field.


### PR DESCRIPTION
## Issue

The className property as an object was optional but when the className is provided it was required to provide all the properties declared or needed in className. 

From chatGPT the more explanation 

```
classNames?: {
  tags: string,
  tagInput: string,
  tagInputField: string,
  selected: string,
  tag: string,
  remove: string,
  suggestions: string,
  activeSuggestion: string,
  editTagInput: string,
  editTagInputField: string,
  clearAll: string,
}
```
The ? here means that classNames itself is optional. You can choose to provide or omit this property.
 Each property inside the classNames object is required if the classNames object is provided. You must include all these properties with corresponding string values if you use the classNames object.
 

## Solution : make each property optional
 
 ```
 
 classNames?: {
  tags?: string,
  tagInput?: string,
  tagInputField?: string,
  selected?: string,
  tag?: string,
  remove?: string,
  suggestions?: string,
  activeSuggestion?: string,
  editTagInput?: string,
  editTagInputField?: string,
  clearAll?: string,
};

 ```
 
 
The ? after classNames means that the classNames property itself is optional. When using this type, you might not provide the classNames property at all.
tags?: string and others: Each property inside the classNames object is also optional. This means that you can provide an object with some, all, or none of these properties.


This fixes https://github.com/react-tags/react-tags/issues/983