### PR TITLE
fix: accessibility issue in clear all cta

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Option | Type | Default | Description
 |[`clearAll`](#clearAll) | `boolean` | `false` | Implies whether 'clear all' button should be shown.
 |[`onClearAll`](#onClearAll) | `Function` |  | This callback if present is triggered when clear all button is clicked.
 | [`maxTags`](#maxTags) | `number` | | The maximum count of tags to be added
+| [`ariaAttrs`](#ariaAttrs) | Object |`{clearAllLabel: "clear all tags"}` | An object used to pass custom accessibility attributes 
 
 ## Styling
 `<ReactTags>` does not come up with any styles. However, it is very easy to customize the look of the component the way you want it. By default, the component provides the following classes with which you can style -
@@ -699,4 +700,9 @@ This callback is if present is triggered when "clear all" button is clicked. You
 
 ### maxTags
 This prop specifies the maximum count of tags to be added. Incase the tags exceed, error will show up to convey the maximum tag limit has reached.
+
+### ariaAttrs
+
+An object used to pass custom accessibility attributes (ARIA properties) to enhance screen reader support and improve accessibility. For example, clearAllLabel defines the accessible label for a "clear all tags" button, providing context for assistive technologies.
+
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Option | Type | Default | Description
 |[`clearAll`](#clearAll) | `boolean` | `false` | Implies whether 'clear all' button should be shown.
 |[`onClearAll`](#onClearAll) | `Function` |  | This callback if present is triggered when clear all button is clicked.
 | [`maxTags`](#maxTags) | `number` | | The maximum count of tags to be added
-| [`ariaAttrs`](#ariaAttrs) | Object |`{clearAllLabel: "clear all tags"}` | An object used to pass custom accessibility attributes 
+| [`ariaAttrs`](#ariaAttrs) | Object |`{clearAllLabel: "clear all tags"}` | An object containing custom ARIA attributes to enhance screen reader support and improve accessibility
 
 ## Styling
 `<ReactTags>` does not come up with any styles. However, it is very easy to customize the look of the component the way you want it. By default, the component provides the following classes with which you can style -
@@ -703,6 +703,11 @@ This prop specifies the maximum count of tags to be added. Incase the tags excee
 
 ### ariaAttrs
 
-An object used to pass custom accessibility attributes (ARIA properties) to enhance screen reader support and improve accessibility. For example, clearAllLabel defines the accessible label for a "clear all tags" button, providing context for assistive technologies.
+An object containing custom ARIA attributes to enhance screen reader support and improve accessibility. 
+It accepts the below attributes
+```js
+{
+  clearAllLabel?: string // Optional accessible label for a "clear all tags" button improving accessibility by providing a clear, descriptive action label.
+}
 
 

--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -1323,7 +1323,7 @@ describe('Test ReactTags', () => {
 
     })
 
-      it('should have  value for aria-label when label is provided', () => {
+      it('should have value for aria-label when label is provided', () => {
       const tags = render(
         mockItem({
           clearAll: true,

--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -1362,7 +1362,7 @@ describe('Test ReactTags', () => {
             Clear all
           </button>
       `);
-      tags.debug();
+      
     });
 
     it('should trigger "onClearAll" callback if present when clear all button is clicked', () => {

--- a/__tests__/ReactTags.test.tsx
+++ b/__tests__/ReactTags.test.tsx
@@ -1304,20 +1304,65 @@ describe('Test ReactTags', () => {
   });
 
   describe('When ClearAll is true', () => {
+    it('should have default value for aria-label when label is not provided', () => {
+      const tags = render(
+        mockItem({
+          clearAll: true,
+        })
+      )
+
+       jestExpect(tags.container.querySelector('.ReactTags__clearAll'))
+        .toMatchInlineSnapshot(`
+        <button
+          aria-label="clear all tags"
+          class="ReactTags__clearAll"
+        >
+          Clear all
+        </button>
+      `);
+
+    })
+
+      it('should have  value for aria-label when label is provided', () => {
+      const tags = render(
+        mockItem({
+          clearAll: true,
+          ariaAttrs: {
+            clearAllLabel: 'Clear all selected tags'
+          }
+        })
+      )
+
+       jestExpect(tags.container.querySelector('.ReactTags__clearAll'))
+        .toMatchInlineSnapshot(`
+        <button
+          aria-label="Clear all selected tags"
+          class="ReactTags__clearAll"
+        >
+          Clear all
+        </button>
+      `);
+
+    })
+
     it('should render a clear all button', () => {
       const tags = render(
         mockItem({
           clearAll: true,
         })
       );
-      jestExpect(tags.container.querySelector('.ReactTags__clearAll'))
+      
+      
+      jestExpect(tags.container.querySelector('.ReactTags__clearAll'))      
         .toMatchInlineSnapshot(`
-        <button
-          class="ReactTags__clearAll"
-        >
-          Clear all
-        </button>
+          <button
+            aria-label="clear all tags"
+            class="ReactTags__clearAll"
+          >
+            Clear all
+          </button>
       `);
+      tags.debug();
     });
 
     it('should trigger "onClearAll" callback if present when clear all button is clicked', () => {

--- a/src/components/ClearAllTags.tsx
+++ b/src/components/ClearAllTags.tsx
@@ -4,11 +4,11 @@ const ClearAllTags = (props: {
   classNames: {
     clearAll: string,
   },
-  accessibilityLabel?: string,
+  ariaLabel?: string,
   onClick: () => void,
 }) => {
   return (
-    <button aria-label={props.accessibilityLabel} className={props.classNames.clearAll} onClick={props.onClick}>
+    <button aria-label={props.ariaLabel} className={props.classNames.clearAll} onClick={props.onClick}>
       Clear all
     </button>
   );

--- a/src/components/ClearAllTags.tsx
+++ b/src/components/ClearAllTags.tsx
@@ -4,7 +4,7 @@ const ClearAllTags = (props: {
   classNames: {
     clearAll: string,
   },
-  accessibilityLabel: string,
+  accessibilityLabel?: string,
   onClick: () => void,
 }) => {
   return (

--- a/src/components/ClearAllTags.tsx
+++ b/src/components/ClearAllTags.tsx
@@ -4,11 +4,11 @@ const ClearAllTags = (props: {
   classNames: {
     clearAll: string,
   },
-  ariaLabel?: string,
+  'aria-label'?: string,
   onClick: () => void,
 }) => {
   return (
-    <button aria-label={props.ariaLabel} className={props.classNames.clearAll} onClick={props.onClick}>
+    <button aria-label={props['aria-label']} className={props.classNames.clearAll} onClick={props.onClick}>
       Clear all
     </button>
   );

--- a/src/components/ClearAllTags.tsx
+++ b/src/components/ClearAllTags.tsx
@@ -4,10 +4,11 @@ const ClearAllTags = (props: {
   classNames: {
     clearAll: string,
   },
+  accessibilityLabel: string,
   onClick: () => void,
 }) => {
   return (
-    <button className={props.classNames.clearAll} onClick={props.onClick}>
+    <button aria-label={props.accessibilityLabel} className={props.classNames.clearAll} onClick={props.onClick}>
       Clear all
     </button>
   );

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -554,7 +554,7 @@ const ReactTags = (props: ReactTagsProps) => {
         renderSuggestion={props.renderSuggestion}
       />
       {clearAll && tags.length > 0 && (
-        <ClearAllTags ariaLabel={ariaAttrs?.clearAllLabel } classNames={allClassNames} onClick={handleClearAll} />
+        <ClearAllTags aria-label={ariaAttrs?.clearAllLabel } classNames={allClassNames} onClick={handleClearAll} />
       )}
       {error && (
         <div data-testid="error" className="ReactTags__error">

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -554,7 +554,7 @@ const ReactTags = (props: ReactTagsProps) => {
         renderSuggestion={props.renderSuggestion}
       />
       {clearAll && tags.length > 0 && (
-        <ClearAllTags accessibilityLabel={ariaAttrs?.clearAllLabel } classNames={allClassNames} onClick={handleClearAll} />
+        <ClearAllTags ariaLabel={ariaAttrs?.clearAllLabel } classNames={allClassNames} onClick={handleClearAll} />
       )}
       {error && (
         <div data-testid="error" className="ReactTags__error">

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -41,6 +41,7 @@ type ReactTagsProps = ReactTagsWrapperProps & {
   inputProps: { [key: string]: string };
   editable: boolean;
   clearAll: boolean;
+  accessibilityLabelForClearAll?: string;
 };
 
 const ReactTags = (props: ReactTagsProps) => {
@@ -70,6 +71,7 @@ const ReactTags = (props: ReactTagsProps) => {
     maxLength,
     inputValue,
     clearAll,
+    accessibilityLabelForClearAll = 'clear all selected tags',
   } = props;
 
   const [suggestions, setSuggestions] = useState(props.suggestions);
@@ -550,7 +552,7 @@ const ReactTags = (props: ReactTagsProps) => {
         renderSuggestion={props.renderSuggestion}
       />
       {clearAll && tags.length > 0 && (
-        <ClearAllTags classNames={allClassNames} onClick={handleClearAll} />
+        <ClearAllTags accessibilityLabel={accessibilityLabelForClearAll} classNames={allClassNames} onClick={handleClearAll} />
       )}
       {error && (
         <div data-testid="error" className="ReactTags__error">

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -41,7 +41,9 @@ type ReactTagsProps = ReactTagsWrapperProps & {
   inputProps: { [key: string]: string };
   editable: boolean;
   clearAll: boolean;
-  accessibilityLabelForClearAll?: string;
+  ariaAttrs?: {
+    clearAllLabel?: string
+  }
 };
 
 const ReactTags = (props: ReactTagsProps) => {
@@ -71,7 +73,7 @@ const ReactTags = (props: ReactTagsProps) => {
     maxLength,
     inputValue,
     clearAll,
-    accessibilityLabelForClearAll = 'clear all selected tags',
+    ariaAttrs,
   } = props;
 
   const [suggestions, setSuggestions] = useState(props.suggestions);
@@ -552,7 +554,7 @@ const ReactTags = (props: ReactTagsProps) => {
         renderSuggestion={props.renderSuggestion}
       />
       {clearAll && tags.length > 0 && (
-        <ClearAllTags accessibilityLabel={accessibilityLabelForClearAll} classNames={allClassNames} onClick={handleClearAll} />
+        <ClearAllTags accessibilityLabel={ariaAttrs?.clearAllLabel } classNames={allClassNames} onClick={handleClearAll} />
       )}
       {error && (
         <div data-testid="error" className="ReactTags__error">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,6 +198,10 @@ export interface ReactTagsWrapperProps {
    */
   clearAll?: boolean;
   /**
+   * accessibility la
+   */
+  accessibilityLabelForClearAll?: string;
+  /**
    * Handler for clearing all the tags.
    */
   onClearAll?: () => void;
@@ -228,6 +232,7 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
     inputProps = {},
     editable = false,
     clearAll = false,
+    accessibilityLabelForClearAll="clear all selected tags",
     handleDelete,
     handleAddition,
     onTagUpdate,
@@ -271,6 +276,7 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
       inputProps={inputProps}
       editable={editable}
       clearAll={clearAll}
+      accessibilityLabelForClearAll={accessibilityLabelForClearAll}
       handleDelete={handleDelete}
       handleAddition={handleAddition}
       onTagUpdate={onTagUpdate}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,7 +198,7 @@ export interface ReactTagsWrapperProps {
    */
   clearAll?: boolean;
   /**
-   * accessibility la
+   * accessibility label for clear all button
    */
   accessibilityLabelForClearAll?: string;
   /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -235,7 +235,7 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
     inputProps = {},
     editable = false,
     clearAll = false,
-    ariaAttrs = { clearAllLabel: "clear all tags"},
+    ariaAttrs = { clearAllLabel: "clear all tags"}, 
     handleDelete,
     handleAddition,
     onTagUpdate,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,10 +198,10 @@ export interface ReactTagsWrapperProps {
    */
   clearAll?: boolean;
   /**
-   * object to hold accessibility attributes for below list
-   *  - label for clear all button
+   * An object containing custom aria attributes to improve acceessibility
    */
   ariaAttrs?: {
+  // label for clear all button
     clearAllLabel?: string
   };
   /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -198,9 +198,12 @@ export interface ReactTagsWrapperProps {
    */
   clearAll?: boolean;
   /**
-   * accessibility label for clear all button
+   * object to hold accessibility attributes for below list
+   *  - label for clear all button
    */
-  accessibilityLabelForClearAll?: string;
+  ariaAttrs?: {
+    clearAllLabel?: string
+  };
   /**
    * Handler for clearing all the tags.
    */
@@ -232,7 +235,7 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
     inputProps = {},
     editable = false,
     clearAll = false,
-    accessibilityLabelForClearAll="clear all selected tags",
+    ariaAttrs = { clearAllLabel: "clear all tags"},
     handleDelete,
     handleAddition,
     onTagUpdate,
@@ -276,7 +279,7 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
       inputProps={inputProps}
       editable={editable}
       clearAll={clearAll}
-      accessibilityLabelForClearAll={accessibilityLabelForClearAll}
+      ariaAttrs={ariaAttrs}
       handleDelete={handleDelete}
       handleAddition={handleAddition}
       onTagUpdate={onTagUpdate}


### PR DESCRIPTION
## Fix

**Issue:** Clear all buttons don’t explain what to clear. it feels like I am trying to clear texts in input but actually, it does clear tags

**solution** : Give a prop to provide an alt tag to clear all CTA in case CTA is provided. If not give the default alt tag as “clear all chosen tags”


accessibility tree
| then | now |
|--|--|
|<img width="1015" alt="Screenshot 2024-10-01 at 8 19 04 PM" src="https://github.com/user-attachments/assets/dfefd9df-e9a2-45f6-9760-367c135c5e1b"> | <img width="1053" alt="image" src="https://github.com/user-attachments/assets/b3064825-1eb5-4770-a1cb-c24e7178141a">|

screen reader announcement when clear all CTA is being focused 

<img width="1352" alt="Screenshot 2024-10-01 at 8 41 28 PM" src="https://github.com/user-attachments/assets/1bdf12c4-bbe5-4952-b21a-b2c63d30a6da">

This fixes first issue in https://github.com/react-tags/react-tags/issues/999
