### PR TITLE
feat: accept labelledById prop to provide label for input tags

### DIFF
--- a/example/main.tsx
+++ b/example/main.tsx
@@ -67,9 +67,10 @@ const App = () => {
   return (
     <div className="app">
       <GitHubCorner />
-      <h1> React Tags Example </h1>
+      <h1 id="react-tags-example"> React Tags Example </h1>
       <div>
         <ReactTags
+          labelledById="react-tags-example"
           tags={tags}
           suggestions={suggestions}
           separators={[SEPARATORS.ENTER, SEPARATORS.COMMA]}

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -41,6 +41,7 @@ type ReactTagsProps = ReactTagsWrapperProps & {
   inputProps: { [key: string]: string };
   editable: boolean;
   clearAll: boolean;
+  labelledById: string;
 };
 
 const ReactTags = (props: ReactTagsProps) => {
@@ -70,6 +71,7 @@ const ReactTags = (props: ReactTagsProps) => {
     maxLength,
     inputValue,
     clearAll,
+    labelledById,
   } = props;
 
   const [suggestions, setSuggestions] = useState(props.suggestions);
@@ -469,6 +471,7 @@ const ReactTags = (props: ReactTagsProps) => {
                 }}
                 onFocus={handleFocus}
                 value={query}
+                aria-label={`Editing tag ${query} of ${labelledById}`}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
                 onBlur={handleBlur}
@@ -522,7 +525,7 @@ const ReactTags = (props: ReactTagsProps) => {
         className={allClassNames.tagInputField}
         type="text"
         placeholder={placeholder}
-        aria-label={placeholder}
+        aria-labelledby={labelledById}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onChange={handleChange}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,10 @@ import {
 
 export interface ReactTagsWrapperProps {
   /**
+   * Id of the label of the input field and the tags container.
+   */
+  labelledById: string;
+  /**
    * Placeholder text for the input field.
    */
   placeholder?: string;
@@ -248,10 +252,12 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
     inputValue,
     maxTags,
     renderSuggestion,
+    labelledById,
   } = props;
 
   return (
     <ReactTags
+      labelledById={labelledById}
       placeholder={placeholder}
       labelField={labelField}
       suggestions={suggestions}


### PR DESCRIPTION
## ADDED
 `labelledById`: a required prop. This is the ID of the label of the input field and the tag container

## FIX

Issue: For assistive technology users 
  1. when they input value to a  tag name, they will not have any context on what they are inputting for
  2. When they edit pre-added tags they will not know what they are editing and the context of tags.

Solution : 
1. accept a mandatory prop `labelledById` an id to label for both tag and input. 

Screenshot VO when editing tag

![Screenshot 2024-10-02 at 11 06 48 AM](https://github.com/user-attachments/assets/599a7267-487e-423e-b9d5-cbf11b4321f8)

accessibility tree when editing tag
|then|now|
|--|--|
|![Screenshot 2024-10-02 at 11 46 39 AM](https://github.com/user-attachments/assets/a1c742e8-0818-4cb9-8616-0b5c7bd6c9dc)|![Screenshot 2024-10-02 at 11 07 04 AM (2)](https://github.com/user-attachments/assets/3c4486f2-33b2-47c8-b093-607680d5c05b)|
| ![Screenshot 2024-10-02 at 11 46 27 AM](https://github.com/user-attachments/assets/0df058c8-bde2-4a02-b2f1-7baeeab160fe)| ![image](https://github.com/user-attachments/assets/6cfe0347-315f-49ac-9751-b9a8e5983dce)|

screenshot of VO on input 
![Screenshot 2024-10-02 at 11 05 57 AM (2)](https://github.com/user-attachments/assets/68bf3a69-9ac0-4613-a47d-465896c1c2c8)


