### PR TITLE
fix: accessibility issue in suggestions

### DIFF
--- a/example/main.tsx
+++ b/example/main.tsx
@@ -67,9 +67,10 @@ const App = () => {
   return (
     <div className="app">
       <GitHubCorner />
-      <h1> React Tags Example </h1>
+      <h1 id="react-tags-example"> React Tags Example </h1>
       <div>
         <ReactTags
+          labelledById="react-tags-example"
           tags={tags}
           suggestions={suggestions}
           separators={[SEPARATORS.ENTER, SEPARATORS.COMMA]}

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -41,6 +41,7 @@ type ReactTagsProps = ReactTagsWrapperProps & {
   inputProps: { [key: string]: string };
   editable: boolean;
   clearAll: boolean;
+  labelledById: string;
 };
 
 const ReactTags = (props: ReactTagsProps) => {
@@ -70,6 +71,7 @@ const ReactTags = (props: ReactTagsProps) => {
     maxLength,
     inputValue,
     clearAll,
+    labelledById,
   } = props;
 
   const [suggestions, setSuggestions] = useState(props.suggestions);
@@ -512,6 +514,10 @@ const ReactTags = (props: ReactTagsProps) => {
 
   const position = inline === false ? INPUT_FIELD_POSITIONS.BOTTOM : inputFieldPosition;
 
+  const activeOption = selectedIndex != -1 && query.trim().length >= (minQueryLength || 2) ? `${labelledById}-suggestion-${suggestions[selectedIndex].id.replace(/\s/g, '')}` : undefined
+  
+  const expanded = query.trim().length >= (minQueryLength || 2) && suggestions.length > 0
+
   const tagsComponent = !readOnly ? (
     <div className={allClassNames.tagInput}>
       <input
@@ -519,6 +525,13 @@ const ReactTags = (props: ReactTagsProps) => {
         ref={(input) => {
           textInput.current = input;
         }}
+        aria-expanded={expanded}
+        data-active-option={activeOption}
+        aria-haspopup='listbox'
+        aria-activedescendant={activeOption}
+        role='combobox'
+        aria-controls={`${labelledById}-suggestions`}
+        aria-autocomplete='list'
         className={allClassNames.tagInputField}
         type="text"
         placeholder={placeholder}
@@ -537,6 +550,7 @@ const ReactTags = (props: ReactTagsProps) => {
       />
 
       <Suggestions
+        labelledById={labelledById}
         query={query.trim()}
         suggestions={suggestions}
         labelField={labelField}
@@ -593,6 +607,16 @@ const ReactTags = (props: ReactTagsProps) => {
         {position === INPUT_FIELD_POSITIONS.INLINE && tagsComponent}
       </div>
       {position === INPUT_FIELD_POSITIONS.BOTTOM && tagsComponent}
+      <span role='alert' style={{
+          position: 'absolute',
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          margin: '-1px',
+          padding: 0,
+          width: '1px',
+          height: '1px',
+          border: 0,
+        }} className="sr-only" aria-live="polite" aria-atomic="true" >{`${query.trim().length >= (minQueryLength || 2) && suggestions.length ? suggestions.length : 0} suggestions`} </span>
     </div>
   );
 };

--- a/src/components/Suggestions.tsx
+++ b/src/components/Suggestions.tsx
@@ -31,6 +31,10 @@ const shouldRenderSuggestions = (
 };
 
 interface SuggestionsProps {
+    /**
+   * Id of the label of the input field and the tags container.
+   */
+  labelledById: string;
   /**
    * The current query string.
    */
@@ -121,7 +125,7 @@ const SuggestionsComp = (props: SuggestionsProps) => {
 
     return {
       __html: labelValue.replace(RegExp(escapedRegex, 'gi'), (x: string) => {
-        return `<mark>${escape(x)}</mark>`;
+        return `<mark role="presentation">${escape(x)}</mark>`;
       }),
     };
   };
@@ -130,13 +134,15 @@ const SuggestionsComp = (props: SuggestionsProps) => {
     if (typeof props.renderSuggestion === 'function') {
       return props.renderSuggestion(tag, query);
     }
-    return <span dangerouslySetInnerHTML={markIt(tag, query)} />;
+    return <span aria-label={tag[labelField]}   dangerouslySetInnerHTML={markIt(tag, query)} />;
   };
 
   const suggestions = props.suggestions.map((tag: Tag, index: number) => {
     return (
       <li
-        key={index}
+        id={`${props.labelledById}-suggestion-${tag.id.replace(/\s+/g,'')}`}
+        key={index}     
+        role='option'           
         onMouseDown={props.handleClick.bind(null, index)}
         onTouchStart={props.handleClick.bind(null, index)}
         onMouseOver={props.handleHover.bind(null, index)}
@@ -166,7 +172,7 @@ const SuggestionsComp = (props: SuggestionsProps) => {
       ref={suggestionsContainerRef}
       className={classNames.suggestions}
       data-testid="suggestions">
-      <ul> {suggestions} </ul>
+      <ul id={`${props.labelledById}-suggestions`} role='listbox'> {suggestions} </ul>
     </div>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,10 @@ import {
 
 export interface ReactTagsWrapperProps {
   /**
+   * Id of the label of the input field and the tags container.
+   */
+  labelledById: string;
+  /**
    * Placeholder text for the input field.
    */
   placeholder?: string;
@@ -248,10 +252,12 @@ const ReactTagsWrapper = (props: ReactTagsWrapperProps) => {
     inputValue,
     maxTags,
     renderSuggestion,
+    labelledById
   } = props;
 
   return (
     <ReactTags
+      labelledById={labelledById}
       placeholder={placeholder}
       labelField={labelField}
       suggestions={suggestions}


### PR DESCRIPTION
## ISSUE
1. suggestions are not screen reader accessible, when you move across the suggestions VO doesn’t announce it
2. screen reader should announce the count of suggestions when the suggestion is shown

## SOLUTION
1. This is happening as we are moving across the non-activable element. Usually, VO when reading across the text of the website using ctrl+options+shift , reads the content in any tag. But for tab indexable elements if we are using non-indexable elements, then we need to take care of it. Giving an aria-label to suggestions fixes this. The suggestion itself should be used as aria label.

2. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role

Need to follow the above pattern and aria-live should be added to the suggestion container. So when it’s open it can announce the count of suggestions

Description:
I have followed the pattern in mdn.dev. 

- The input tag should have the role as `combobox`. Here input tag acts as `combobox`
 - The attributes to pass on to combobox
        1. aria-expanded : the attribute that tells suggestions pop-up is open or not
         2. aria-haspopup: this is used to indicate what tag or role is pop-up, if no default value is given it takes list 
        3. aria-controls:  the id of the pop-up combobox is controlling 
       4. A[ria-activedescendant](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant) : which of the options is currently highlighted 
     5. aria-autocomplete:  on clicking suggestion whether the input is auto completed

To maintain the unique id for the suggestions container , I have introduced a new prop called `labelledById`. This is the id of the label that gives the context of the tag. 

screen recording 

https://github.com/user-attachments/assets/45122b43-c061-4221-abf5-d156ff2ff1ae


This PR fixes suggestion related accessibility issue https://github.com/react-tags/react-tags/issues/999