### PR TITLE
fix: nested interaction in tags

### DIFF
--- a/example/main.tsx
+++ b/example/main.tsx
@@ -81,6 +81,7 @@ const App = () => {
           inputFieldPosition="bottom"
           editable
           clearAll
+          readOnly
           onClearAll={onClearAll}
           maxTags={7}
           allowAdditionFromPaste

--- a/src/components/ReactTags.tsx
+++ b/src/components/ReactTags.tsx
@@ -206,12 +206,12 @@ const ReactTags = (props: ReactTagsProps) => {
   const handleTagClick = (
     index: number,
     tag: Tag,
-    event: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement>
+    event: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>
   ) => {
     if (readOnly) {
       return;
     }
-    if (editable) {
+        if (editable) {
       setCurrentEditIndex(index);
       setQuery(tag[labelField]);
       tagInput.current?.focus();
@@ -467,6 +467,7 @@ const ReactTags = (props: ReactTagsProps) => {
                 ref={(input: HTMLInputElement) => {
                   tagInput.current = input;
                 }}
+                autoFocus
                 onFocus={handleFocus}
                 value={query}
                 onChange={handleChange}
@@ -494,6 +495,7 @@ const ReactTags = (props: ReactTagsProps) => {
                 event:
                   | React.MouseEvent<HTMLSpanElement>
                   | React.TouchEvent<HTMLSpanElement>
+                  | React.KeyboardEvent<HTMLSpanElement>
               ) => handleTagClick(index, tag, event)}
               readOnly={readOnly}
               classNames={allClassNames}

--- a/src/components/SingleTag.tsx
+++ b/src/components/SingleTag.tsx
@@ -24,7 +24,7 @@ export interface TagProps {
   moveTag?: (dragIndex: number, hoverIndex: number) => void;
   removeComponent?: React.ComponentType<any>;
   onTagClicked: (
-    event: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement>
+    event: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>
   ) => void;
   classNames: {
     tag: string;
@@ -74,10 +74,21 @@ const SingleTag = (props: TagProps) => {
 
   drag(drop(tagRef));
 
+  // Callback for when the tag is keyboard focused
+  const onTagEdit = (e: React.KeyboardEvent<HTMLSpanElement>) => {    
+    // Enter and Space are the keys that are used to select the tag to edit
+    if (e.key === 'Enter' || e.key === ' ') {
+      props.onTagClicked(e);
+    }
+  };
+
   const label = props.tag[labelField];
   const { className = '' } = tag;
   /* istanbul ignore next */
   const opacity = isDragging ? 0 : 1;
+
+  const ariaLabel = `Tag at index ${index} with value ${tag.id} focussed. Press enter or space to edit.`;
+
   return (
     <span
       ref={tagRef}
@@ -86,7 +97,11 @@ const SingleTag = (props: TagProps) => {
         opacity,
         cursor: canDrag({ moveTag, readOnly, allowDragDrop }) ? 'move' : 'auto',
       }}
+      tabIndex={ readOnly ? -1 : 0}
+      onKeyDown={onTagEdit}
+      role={readOnly ? 'presentation' : 'button'}
       data-testid="tag"
+      aria-label={readOnly ? label : ariaLabel}
       onClick={props.onTagClicked}
       onTouchStart={props.onTagClicked}>
       {label}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -86,7 +86,7 @@ export interface ReactTagsWrapperProps {
    */
   handleTagClick?: (
     i: number,
-    e: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement>
+    e: React.MouseEvent<HTMLSpanElement> | React.TouchEvent<HTMLSpanElement> | React.KeyboardEvent<HTMLSpanElement>
   ) => void;
   /**
    * Whether to allow deletion from an empty input field.


### PR DESCRIPTION
## ISSUE
1. tags are not reachable to edit using the keyboard
2. proper aria label for tags and nested interaction handle


## SOLUTION 
The tag as a whole is keyboard-reachable and activates when clicking enter or space. On active it behaves as an input tag. On behaving as an input tag close icon will be hidden.

The close icon will be in the tab index series when the whole tag acts as a clickable.

When the tag is in read-only mode, the role of the span will be `presentation`. Hence when assistive technology users read the read-only tag it acts as normal text. When read-only tags are not keyboard-focusable. 

## SCREENSHOTS 
The tag as a whole is focused 
<img width="1352" alt="Screenshot 2024-10-05 at 12 18 51 PM" src="https://github.com/user-attachments/assets/e2fe34de-aee7-47d9-9f95-1fa35dec2ade">


the close CTA is focused 
<img width="1352" alt="Screenshot 2024-10-05 at 12 19 01 PM" src="https://github.com/user-attachments/assets/99b68444-7df7-4604-b649-e36ea4fc9f50">

on read-only
 
<img width="1352" alt="Screenshot 2024-10-05 at 12 22 57 PM" src="https://github.com/user-attachments/assets/7d266ee9-4103-43f8-8185-769e3aabe0ef">



